### PR TITLE
chore(deps): use latest version of kwctl

### DIFF
--- a/kwctl-installer/action.yaml
+++ b/kwctl-installer/action.yaml
@@ -7,7 +7,7 @@ inputs:
   KWCTL_VERSION:
     description: 'kwctl release to be installed'
     required: false
-    default: v1.6.0-rc2
+    default: v1.6.0-rc3
 runs:
   using: "composite"
   steps:


### PR DESCRIPTION
Install latest version of kwctl: 1.6.0-rc3

This is needed to run e2e tests of context aware policies

